### PR TITLE
Rename test case to not conflict with macro name

### DIFF
--- a/tests/tests/run-pass.rs
+++ b/tests/tests/run-pass.rs
@@ -142,7 +142,7 @@ fn trailing_whitespace() {
 
 #[cfg(feature = "unstable")]
 #[test]
-fn format() {
+fn indoc_as_format_string() {
     let s = format!(indoc!("{}"), true);
     assert_eq!(s, "true");
 }


### PR DESCRIPTION
This started failing as of nightly-2018-08-03. https://github.com/rust-lang/rust/issues/53144