### PR TITLE
Fix minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 unstable = ["indoc-impl/unstable"]
 
 [dependencies]
-indoc-impl = { version = "0.3", path = "impl" }
+indoc-impl = { version = "0.3.1", path = "impl" }
 proc-macro-hack = "0.5.3"
 
 [workspace]


### PR DESCRIPTION
While #26 checks `-Z minimal-versions` on travis for this repo, downstream crates still break with the error shown below. While on travis it uses the path dependency for indoc-impl (and therefore always 0.3.1), downstream crates select 0.3.0. This PR fixes that by requiring at least 0.3.1; Pinning `=0.3.1` would be another option.

I couldn't properly test this change because using the `[patch]` section makes cargo use the path dependency which then works anyway, but I'm pretty confident that it works.

```
   Compiling indoc-impl v0.3.0
error[E0425]: cannot find function `unindent_bytes` in this scope
  --> /home/konsti/.cargo/registry/src/github.com-1ecc6299db9ec823/indoc-impl-0.3.0/src/lib.rs:57:21
   |
57 |             let v = unindent_bytes(&lit.value());
   |                     ^^^^^^^^^^^^^^ not found in this scope

error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
  --> /home/konsti/.cargo/registry/src/github.com-1ecc6299db9ec823/indoc-impl-0.3.0/src/lib.rs:57:17
   |
57 |             let v = unindent_bytes(&lit.value());
   |                 ^ doesn't have a size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `[u8]`
   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
   = note: all local variables must have a statically known size
   = help: unsized locals are gated as an unstable feature
```