### PR TITLE
Require unindent 0.1.3 for indoc-impl

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-hack = "0.5"
 proc-macro2 = { version = "0.4", default-features = false }
 quote = { version = "0.6", default-features = false }
 syn = { version = "0.15", default-features = false, features = ["derive", "parsing", "printing"] }
-unindent = { version = "0.1", path = "../unindent" }
+unindent = { version = "0.1.3", path = "../unindent" }
 
 [badges]
 travis-ci = { repository = "dtolnay/indoc" }


### PR DESCRIPTION
indoc-impl 0.3.1/0.3.2 also doesn't work with minimal-versions because I failed to update unindent, which I fixed now