### PR TITLE
Fix failing build due to incorrect proc_macro2 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 
 matrix:
   include:
-    - rust: 1.31.0
+    - rust: 1.37.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indoc"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Indented document literals"
@@ -14,8 +14,8 @@ edition = "2018"
 unstable = ["indoc-impl/unstable"]
 
 [dependencies]
-indoc-impl = { version = "=0.3.3", path = "impl" }
-proc-macro-hack = "0.5.3"
+indoc-impl = { version = "=0.3.4", path = "impl" }
+proc-macro-hack = "0.5.9"
 
 [dev-dependencies]
 rustversion = "0.1"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indoc-impl"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Indented document literals"
@@ -18,9 +18,9 @@ proc-macro = true
 
 [dependencies]
 proc-macro-hack = "0.5"
-proc-macro2 = { version = "0.4", default-features = false }
-quote = { version = "0.6", default-features = false }
-syn = { version = "0.15", default-features = false, features = ["derive", "parsing", "printing"] }
+proc-macro2 = { version = "1.0", default-features = false }
+quote = { version = "1.0", default-features = false }
+syn = { version = "1.0", default-features = false, features = ["derive", "parsing", "printing"] }
 unindent = { version = "0.1.3", path = "../unindent" }
 
 [badges]


### PR DESCRIPTION
Hello, 

I just reopened an old project using indoc. Build failed for the indoc/impl crate, seems it was because syn, quote and proc-macro-hack versions used a different proc_procmacro2 version. 

upgrading to the latest proc-macro-hack and 1.0 for syn and quote seems to fix the issue. 