### PR TITLE
`printdoc` and `formatdoc` implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,35 @@ fn main() {
 }
 ```
 
+`indoc` also exports two `format`-like macros - `formatdoc`, which work exactly like `format` and generates the unindented formatted string, and `printdoc`, which prints the unindented formatted string to the standard output:
+
+```rust
+use indoc::formatdoc;
+
+fn main() {
+    let testing = formatdoc!("
+        {}\
+        {}
+        {}\
+          {}
+        {}", 'a', 'b', 'c', 'd', 'e');
+    let expected = "ab\ncd\ne";
+    assert_eq!(testing, expected);
+}
+```
+Note that these macros, just like `format` and `print`, do not support binary strings. Also, the format string is unindented and not the formatted one:
+```rust
+use indoc::formatdoc;
+
+fn main() {
+    let testing = formatdoc!("\
+        {}", " a");
+    let expected = " a";
+    // The leading space in the substitution is preserved.
+    assert_eq!(testing, expected);
+}
+```
+
 ## Explanation
 
 The following rules characterize the behavior of the `indoc!()` macro:

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -21,6 +21,32 @@ pub fn indoc(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(unindented)
 }
 
+#[cfg_attr(feature = "unstable", proc_macro)]
+#[cfg_attr(not(feature = "unstable"), proc_macro_hack)]
+pub fn formatdoc(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = TokenStream::from(input);
+
+    let format = match format_indoc(input, "format") {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    };
+
+    proc_macro::TokenStream::from(format)
+}
+
+#[cfg_attr(feature = "unstable", proc_macro)]
+#[cfg_attr(not(feature = "unstable"), proc_macro_hack)]
+pub fn printdoc(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = TokenStream::from(input);
+
+    let format = match format_indoc(input, "print") {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    };
+
+    proc_macro::TokenStream::from(format)
+}
+
 fn try_indoc(input: TokenStream) -> Result<TokenStream> {
     let len = input.clone().into_iter().count();
     if len != 1 {
@@ -32,12 +58,15 @@ fn try_indoc(input: TokenStream) -> Result<TokenStream> {
             ),
         ));
     }
+    lit_indoc(input, true)
+}
 
+fn lit_indoc(input: TokenStream, raw: bool) -> Result<TokenStream> {
     let lit = match syn::parse2::<Lit>(input) {
         Ok(lit) => lit,
-        Err(_) => {
+        Err(err) => {
             return Err(Error::new(
-                Span::call_site(),
+                err.span(),
                 "argument must be a single string literal",
             ));
         }
@@ -49,16 +78,42 @@ fn try_indoc(input: TokenStream) -> Result<TokenStream> {
             Lit::Str(LitStr::new(&v, lit.span()))
         }
         Lit::ByteStr(lit) => {
-            let v = unindent_bytes(&lit.value());
-            Lit::ByteStr(LitByteStr::new(&v, lit.span()))
+            if raw {
+                let v = unindent_bytes(&lit.value());
+                Lit::ByteStr(LitByteStr::new(&v, lit.span()))
+            } else {
+                return Err(Error::new_spanned(
+                    lit,
+                    "byte strings are not supported in formatting macros",
+                ));
+            }
         }
-        _ => {
-            return Err(Error::new(
-                Span::call_site(),
+        otherwise => {
+            return Err(Error::new_spanned(
+                otherwise,
                 "argument must be a single string literal",
             ));
         }
     };
 
     Ok(quote!(#lit))
+}
+
+fn format_indoc(input: TokenStream, macro_name: &str) -> Result<TokenStream> {
+    let macro_name = syn::Ident::new(macro_name, Span::call_site());
+
+    let mut input = input.into_iter();
+
+    let first = std::iter::once(input.next().ok_or_else(|| {
+        Error::new(
+            Span::call_site(),
+            "unexpected end of macro invocation, expected format string",
+        )
+    })?)
+    .collect();
+    let fmt_str = lit_indoc(first, false)?;
+
+    let args: TokenStream = input.collect();
+
+    Ok(quote!(#macro_name!(#fmt_str #args)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,40 @@
 //! }
 //! ```
 //!
+//! `indoc` also exports two `format`-like macros - `formatdoc`, which work exactly
+//! like `format` and generates the unindented formatted string, and `printdoc`,
+//! which prints the unindented formatted string to the standard output:
+//!
+//! ```
+#![cfg_attr(feature = "unstable", doc = " #![feature(proc_macro_hygiene)]")]
+#![cfg_attr(feature = "unstable", doc = "")]
+//! use indoc::formatdoc;
+//!
+//! fn main() {
+//!     let testing = formatdoc!("
+//!         {}\
+//!         {}
+//!         {}\
+//!           {}
+//!         {}", 'a', 'b', 'c', 'd', 'e');
+//!     let expected = "ab\ncd\ne";
+//!     assert_eq!(testing, expected);
+//! }
+//! ```
+//! Note that these macros, just like `format` and `print`, do not support binary
+//! strings. Also, the format string is unindented and not the formatted one:
+//! ```
+//! use indoc::formatdoc;
+//!
+//! fn main() {
+//!     let testing = formatdoc!("\
+//!         {}", " a");
+//!     let expected = " a";
+//!     // The leading space in the substitution is preserved.
+//!     assert_eq!(testing, expected);
+//! }
+//! ```
+//!
 //! # Explanation
 //!
 //! The following rules characterize the behavior of the `indoc!()` macro:
@@ -105,3 +139,9 @@ use proc_macro_hack::proc_macro_hack;
 
 #[cfg_attr(not(feature = "unstable"), proc_macro_hack)]
 pub use indoc_impl::indoc;
+
+#[cfg_attr(not(feature = "unstable"), proc_macro_hack)]
+pub use indoc_impl::formatdoc;
+
+#[cfg_attr(not(feature = "unstable"), proc_macro_hack)]
+pub use indoc_impl::printdoc;

--- a/tests/formatdoc.rs
+++ b/tests/formatdoc.rs
@@ -1,0 +1,107 @@
+#![cfg_attr(feature = "unstable", feature(proc_macro_hygiene))]
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+use indoc::formatdoc;
+
+#[test]
+fn carriage_return() {
+    // Every line in the string ends with \r\n
+    let indoc = formatdoc!("
+        {}
+
+            \\{}
+        {}", 'a', 'b', 'c');
+    let expected = "a\n\n    \\b\nc";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn empty_string() {
+    let indoc = formatdoc!("");
+    let expected = "";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn joined_first_line() {
+    let indoc = formatdoc!("\
+        {}", 'a');
+    let expected = "a";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn joined_lines() {
+    let indoc = formatdoc!("
+        {}\
+        {}
+        {}\
+          {}
+        {}", 'a', 'b', 'c', 'd', 'e');
+    let expected = "ab\ncd\ne";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn no_leading_newline() {
+    let indoc = formatdoc!("{}
+                        {}
+                        {}", 'a', 'b', 'c');
+    let expected = "a\nb\nc";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn one_line() {
+    let indoc = formatdoc!("a");
+    let expected = "a";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn raw_string() {
+    let indoc = formatdoc!(r#"
+        {:?}
+
+            \\{}
+        {}"#, "a", 'b', 'c');
+    let expected = "\"a\"\n\n    \\\\b\nc";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn string() {
+    let indoc = formatdoc!("
+        {}
+
+            \\{}
+        {}", 'a', 'b', 'c');
+    let expected = "a\n\n    \\b\nc";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn string_trailing_newline() {
+    let indoc = formatdoc!("
+        {}
+
+            \\{}
+        {}
+    ", 'a', 'b', 'c');
+    let expected = "a\n\n    \\b\nc\n";
+    assert_eq!(indoc, expected);
+}
+
+#[test]
+fn trailing_whitespace() {
+    let indoc = formatdoc!("
+        {} {below}
+          
+        {} {below}
+        
+        {} {below}
+      
+        end", 2, 0, -2, below = "below");
+    let expected = "2 below\n  \n0 below\n\n-2 below\n\nend";
+    assert_eq!(indoc, expected);
+}

--- a/tests/ui-stable/non-lit.stderr
+++ b/tests/ui-stable/non-lit.stderr
@@ -1,7 +1,7 @@
 error: argument must be a single string literal
- --> $DIR/non-lit.rs:4:5
+ --> $DIR/non-lit.rs:4:12
   |
 4 |     indoc!(fail);
-  |     ^^^^^^^^^^^^^
+  |            ^^^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/non-string.stderr
+++ b/tests/ui-stable/non-string.stderr
@@ -1,7 +1,7 @@
 error: argument must be a single string literal
- --> $DIR/non-string.rs:4:5
+ --> $DIR/non-string.rs:4:12
   |
 4 |     indoc!(64);
-  |     ^^^^^^^^^^^
+  |            ^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/printdoc-binary.rs
+++ b/tests/ui-stable/printdoc-binary.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!(b"");
+}

--- a/tests/ui-stable/printdoc-binary.stderr
+++ b/tests/ui-stable/printdoc-binary.stderr
@@ -1,0 +1,7 @@
+error: byte strings are not supported in formatting macros
+ --> $DIR/printdoc-binary.rs:4:15
+  |
+4 |     printdoc!(b"");
+  |               ^^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/printdoc-extra-arg.rs
+++ b/tests/ui-stable/printdoc-extra-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("", 0);
+}

--- a/tests/ui-stable/printdoc-extra-arg.stderr
+++ b/tests/ui-stable/printdoc-extra-arg.stderr
@@ -1,0 +1,9 @@
+error: argument never used
+ --> $DIR/printdoc-extra-arg.rs:4:19
+  |
+4 |     printdoc!("", 0);
+  |               --  ^ argument never used
+  |               |
+  |               formatting specifier missing
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/printdoc-no-arg.rs
+++ b/tests/ui-stable/printdoc-no-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("{}");
+}

--- a/tests/ui-stable/printdoc-no-arg.stderr
+++ b/tests/ui-stable/printdoc-no-arg.stderr
@@ -1,0 +1,7 @@
+error: 1 positional argument in format string, but no arguments were given
+ --> $DIR/printdoc-no-arg.rs:4:16
+  |
+4 |     printdoc!("{}");
+  |                ^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/printdoc-no-display.rs
+++ b/tests/ui-stable/printdoc-no-display.rs
@@ -1,0 +1,7 @@
+use indoc::printdoc;
+
+struct NoDisplay;
+
+fn main() {
+    printdoc!("{}", NoDisplay);
+}

--- a/tests/ui-stable/printdoc-no-display.stderr
+++ b/tests/ui-stable/printdoc-no-display.stderr
@@ -1,0 +1,10 @@
+error[E0277]: `NoDisplay` doesn't implement `std::fmt::Display`
+ --> $DIR/printdoc-no-display.rs:6:21
+  |
+6 |     printdoc!("{}", NoDisplay);
+  |                     ^^^^^^^^^ `NoDisplay` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `NoDisplay`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required by `std::fmt::Display::fmt`
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/printdoc-no-named-arg.rs
+++ b/tests/ui-stable/printdoc-no-named-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("{named}");
+}

--- a/tests/ui-stable/printdoc-no-named-arg.stderr
+++ b/tests/ui-stable/printdoc-no-named-arg.stderr
@@ -1,0 +1,7 @@
+error: there is no argument named `named`
+ --> $DIR/printdoc-no-named-arg.rs:4:16
+  |
+4 |     printdoc!("{named}");
+  |                ^^^^^^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-unstable/non-lit.stderr
+++ b/tests/ui-unstable/non-lit.stderr
@@ -1,7 +1,5 @@
 error: argument must be a single string literal
- --> $DIR/non-lit.rs:6:5
+ --> $DIR/non-lit.rs:6:12
   |
 6 |     indoc!(fail);
-  |     ^^^^^^^^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  |            ^^^^

--- a/tests/ui-unstable/non-string.stderr
+++ b/tests/ui-unstable/non-string.stderr
@@ -1,7 +1,5 @@
 error: argument must be a single string literal
- --> $DIR/non-string.rs:6:5
+ --> $DIR/non-string.rs:6:12
   |
 6 |     indoc!(64);
-  |     ^^^^^^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  |            ^^

--- a/tests/ui-unstable/printdoc-binary.rs
+++ b/tests/ui-unstable/printdoc-binary.rs
@@ -1,0 +1,7 @@
+#![feature(proc_macro_hygiene)]
+
+use indoc::printdoc;
+
+fn main() {
+    printdoc!(b"");
+}

--- a/tests/ui-unstable/printdoc-binary.stderr
+++ b/tests/ui-unstable/printdoc-binary.stderr
@@ -1,0 +1,5 @@
+error: byte strings are not supported in formatting macros
+ --> $DIR/printdoc-binary.rs:6:15
+  |
+6 |     printdoc!(b"");
+  |               ^^^

--- a/tests/ui-unstable/printdoc-extra-arg.rs
+++ b/tests/ui-unstable/printdoc-extra-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("", 0);
+}

--- a/tests/ui-unstable/printdoc-extra-arg.stderr
+++ b/tests/ui-unstable/printdoc-extra-arg.stderr
@@ -1,0 +1,7 @@
+error: argument never used
+ --> $DIR/printdoc-extra-arg.rs:4:19
+  |
+4 |     printdoc!("", 0);
+  |               --  ^ argument never used
+  |               |
+  |               formatting specifier missing

--- a/tests/ui-unstable/printdoc-no-arg.rs
+++ b/tests/ui-unstable/printdoc-no-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("{}");
+}

--- a/tests/ui-unstable/printdoc-no-arg.stderr
+++ b/tests/ui-unstable/printdoc-no-arg.stderr
@@ -1,0 +1,5 @@
+error: 1 positional argument in format string, but no arguments were given
+ --> $DIR/printdoc-no-arg.rs:4:16
+  |
+4 |     printdoc!("{}");
+  |                ^^

--- a/tests/ui-unstable/printdoc-no-display.rs
+++ b/tests/ui-unstable/printdoc-no-display.rs
@@ -1,0 +1,7 @@
+use indoc::printdoc;
+
+struct NoDisplay;
+
+fn main() {
+    printdoc!("{}", NoDisplay);
+}

--- a/tests/ui-unstable/printdoc-no-display.stderr
+++ b/tests/ui-unstable/printdoc-no-display.stderr
@@ -1,0 +1,10 @@
+error[E0277]: `NoDisplay` doesn't implement `std::fmt::Display`
+ --> $DIR/printdoc-no-display.rs:6:21
+  |
+6 |     printdoc!("{}", NoDisplay);
+  |                     ^^^^^^^^^ `NoDisplay` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `NoDisplay`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required by `std::fmt::Display::fmt`
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-unstable/printdoc-no-named-arg.rs
+++ b/tests/ui-unstable/printdoc-no-named-arg.rs
@@ -1,0 +1,5 @@
+use indoc::printdoc;
+
+fn main() {
+    printdoc!("{named}");
+}

--- a/tests/ui-unstable/printdoc-no-named-arg.stderr
+++ b/tests/ui-unstable/printdoc-no-named-arg.stderr
@@ -1,0 +1,5 @@
+error: there is no argument named `named`
+ --> $DIR/printdoc-no-named-arg.rs:4:16
+  |
+4 |     printdoc!("{named}");
+  |                ^^^^^^^


### PR DESCRIPTION
Two new macros are introduced: `printdoc` and `formatdoc`, which expand to `print` and `format` invocations correspondingly, unindenting the first argument (which must be a literal string) and passing all others as-is.

`formatdoc` is tested for correctness using a little modified test cases from `indoc`; `printdoc` is tested for UX by providing `trybuild` test cases. Since their implementation is exactly identical, except for the name of the macro they are expanding to, this should cover all essential cases.
Also, existing errors are made a little more precise, by pointing on the argument and not on the whole macro.

Closes #36 