### PR TITLE
Work around 1.45's placement of whitespace inside tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,7 @@ fn try_expand(input: TokenStream, mode: Macro) -> Result<TokenStream> {
 
 fn lit_indoc(token: TokenTree, mode: Macro) -> Result<Literal> {
     let repr = token.to_string();
+    let repr = repr.trim();
     let is_string = repr.starts_with('"') || repr.starts_with('r');
     let is_byte_string = repr.starts_with("b\"") || repr.starts_with("br");
 

--- a/tests/test_indoc.rs
+++ b/tests/test_indoc.rs
@@ -149,3 +149,18 @@ fn indoc_as_format_string() {
     let s = format!(indoc! {"{}"}, true);
     assert_eq!(s, "true");
 }
+
+#[test]
+fn test_metavariable() {
+    macro_rules! indoc_wrapper {
+        ($e:expr) => {
+            indoc!($e)
+        };
+    }
+
+    let indoc = indoc_wrapper! {"
+        macros, how do they work
+    "};
+    let expected = "macros, how do they work\n";
+    assert_eq!(indoc, expected);
+}


### PR DESCRIPTION
Rust 1.45.0 was placing whitespace around the string representation of the literal token, though 1.46.0+ does not.

Fixes #39.