### PR TITLE
Preserve last newline even if not indented

### DIFF
--- a/src/unindent.rs
+++ b/src/unindent.rs
@@ -1,4 +1,3 @@
-use std::iter::Peekable;
 use std::slice::Split;
 
 pub fn unindent(s: &str) -> String {
@@ -90,11 +89,11 @@ fn count_spaces(line: &[u8]) -> Option<usize> {
 
 // Based on core::str::StrExt.
 trait BytesExt {
-    fn lines(&self) -> Lines;
+    fn lines(&self) -> Split<u8, fn(&u8) -> bool>;
 }
 
 impl BytesExt for [u8] {
-    fn lines(&self) -> Lines {
+    fn lines(&self) -> Split<u8, fn(&u8) -> bool> {
         fn is_newline(b: &u8) -> bool {
             *b == b'\n'
         }
@@ -103,29 +102,6 @@ impl BytesExt for [u8] {
         } else {
             self
         };
-        Lines {
-            split: bytestring.split(is_newline as fn(&u8) -> bool).peekable(),
-        }
-    }
-}
-
-struct Lines<'a> {
-    split: Peekable<Split<'a, u8, fn(&u8) -> bool>>,
-}
-
-impl<'a> Iterator for Lines<'a> {
-    type Item = &'a [u8];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.split.next() {
-            None => None,
-            Some(fragment) => {
-                if fragment.is_empty() && self.split.peek().is_none() {
-                    None
-                } else {
-                    Some(fragment)
-                }
-            }
-        }
+        bytestring.split(is_newline as fn(&u8) -> bool)
     }
 }

--- a/tests/test_indoc.rs
+++ b/tests/test_indoc.rs
@@ -1,5 +1,15 @@
 use indoc::indoc;
 
+const HELP: &str = indoc! {"
+    Usage: ./foo
+"};
+
+#[test]
+fn test_global() {
+    let expected = "Usage: ./foo\n";
+    assert_eq!(HELP, expected);
+}
+
 #[test]
 fn byte_string() {
     let indoc = indoc! {b"


### PR DESCRIPTION
Previously this:

```rust
fn main() {
    const STRING: &str = indoc! {"
        ...
    "};
}
```

would produce `"...\n"`, while this:

```rust
const STRING: &str = indoc! {"
    ...
"};
```

would produce `"..."`.

That doesn't make sense to me and was probably unintended.

The correct behavior is both should produce `"...\n"`. If you want to get `"..."`,  it needs to be written as:

```rust
const STRING: &str = indoc! {"
    ..."
};
```