### PR TITLE
Update docstring for `indoc!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,9 @@ enum Macro {
     Concat,
 }
 
-/// Unindent and produce `&'static str`.
+/// Unindent and produce `&'static str` or `&'static [u8]`.
+///
+/// Supports normal strings, raw strings, bytestrings, and raw bytestrings.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Before this commit, the docstring seemed to deny bytestring support. I'm guessing it was written before bytestrings were supported.

Feel free to consider this as a PR or as a very minor bug report.